### PR TITLE
feat: add unit-scoped registration links

### DIFF
--- a/prisma/migrations/20260428143000_optional_resident_invite_recipient/migration.sql
+++ b/prisma/migrations/20260428143000_optional_resident_invite_recipient/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "resident_invites" ALTER COLUMN "recipientName" DROP NOT NULL;
+ALTER TABLE "resident_invites" ALTER COLUMN "recipientEmail" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -558,8 +558,8 @@ model ResidentInvite {
   unitId         String
   unit           Unit     @relation(fields: [unitId], references: [id], onDelete: Cascade)
 
-  recipientName  String
-  recipientEmail String
+  recipientName  String?
+  recipientEmail String?
   recipientPhone String?
 
   tokenHash      String   @unique

--- a/src/app/(dashboard)/dashboard/registration-passes/page.tsx
+++ b/src/app/(dashboard)/dashboard/registration-passes/page.tsx
@@ -4,15 +4,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useDebouncedValue } from '@/hooks/use-debounced-value';
 import { useFetchOnChange } from '@/hooks/use-fetch-on-change';
 import { formatDistanceToNow } from 'date-fns';
-import {
-  Copy,
-  Loader2,
-  Mail,
-  Plus,
-  RefreshCcw,
-  Search,
-  ShieldX,
-} from 'lucide-react';
+import { Copy, Loader2, Mail, Plus, RefreshCcw, Search, ShieldX } from 'lucide-react';
 import { toast } from 'sonner';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -35,12 +27,8 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import {
-  CreateResidentInviteDialog,
-} from '@/components/dashboard/create-resident-invite-dialog';
-import {
-  RevokeResidentInviteDialog,
-} from '@/components/dashboard/revoke-resident-invite-dialog';
+import { CreateResidentInviteDialog } from '@/components/dashboard/create-resident-invite-dialog';
+import { RevokeResidentInviteDialog } from '@/components/dashboard/revoke-resident-invite-dialog';
 import {
   handleClickableRowKeyDown,
   stopClickableRowPropagation,
@@ -141,9 +129,7 @@ export default function RegistrationPassesPage() {
       setPagination(data.pagination);
     } catch (fetchError) {
       setError(
-        fetchError instanceof Error
-          ? fetchError.message
-          : 'Failed to load registration passes'
+        fetchError instanceof Error ? fetchError.message : 'Failed to load registration passes'
       );
     } finally {
       setLoading(false);
@@ -154,10 +140,7 @@ export default function RegistrationPassesPage() {
     fetchInvites();
   }, [fetchInvites]);
 
-  const availableUnits = useMemo(
-    () => units.filter((unit) => unit.isAvailableForInvite),
-    [units]
-  );
+  const availableUnits = useMemo(() => units.filter((unit) => unit.isAvailableForInvite), [units]);
 
   async function handleCopyLink() {
     if (!latestInvite) {
@@ -174,7 +157,9 @@ export default function RegistrationPassesPage() {
 
   async function handleReissue(invite: ResidentInviteSummary) {
     const confirmed = window.confirm(
-      `Generate a fresh registration link for ${invite.recipientName}?`
+      `Generate a fresh registration link for ${
+        invite.recipientName ?? `unit ${invite.unit.unitNumber}`
+      }?`
     );
 
     if (!confirmed) {
@@ -202,9 +187,7 @@ export default function RegistrationPassesPage() {
       await fetchInvites();
     } catch (reissueError) {
       toast.error(
-        reissueError instanceof Error
-          ? reissueError.message
-          : 'Failed to reissue registration pass'
+        reissueError instanceof Error ? reissueError.message : 'Failed to reissue registration pass'
       );
     } finally {
       setReissuingInviteId(null);
@@ -222,9 +205,7 @@ export default function RegistrationPassesPage() {
   }
 
   function handleRevoked(invite: ResidentInviteSummary) {
-    setInvites((current) =>
-      current.map((entry) => (entry.id === invite.id ? invite : entry))
-    );
+    setInvites((current) => current.map((entry) => (entry.id === invite.id ? invite : entry)));
     toast.success('Registration pass revoked');
     void fetchInvites();
   }
@@ -233,10 +214,8 @@ export default function RegistrationPassesPage() {
     <div className="space-y-4 md:space-y-6">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
-            Registration Passes
-          </h1>
-          <p className="text-sm md:text-base text-muted-foreground">
+          <h1 className="text-2xl font-bold tracking-tight md:text-3xl">Registration Passes</h1>
+          <p className="text-sm text-muted-foreground md:text-base">
             Issue, revoke, and reissue one-time resident onboarding links.
           </p>
         </div>
@@ -259,7 +238,7 @@ export default function RegistrationPassesPage() {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="rounded-lg border bg-muted/30 p-3 font-mono text-sm break-all">
+            <div className="break-all rounded-lg border bg-muted/30 p-3 font-mono text-sm">
               {latestInvite.registrationUrl}
             </div>
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
@@ -268,8 +247,11 @@ export default function RegistrationPassesPage() {
                   <span>Email delivery succeeded for {latestInvite.invite.recipientEmail}.</span>
                 ) : (
                   <span>
-                    Email delivery failed. Share the link manually with{' '}
-                    {latestInvite.invite.recipientEmail}.
+                    Share this registration link manually
+                    {latestInvite.invite.recipientEmail
+                      ? ` with ${latestInvite.invite.recipientEmail}`
+                      : ''}
+                    .
                   </span>
                 )}
               </div>
@@ -295,8 +277,7 @@ export default function RegistrationPassesPage() {
         <Alert>
           <Mail className="h-4 w-4" />
           <AlertDescription>
-            Every accessible unit already has a primary resident or a pending registration
-            pass.
+            Every accessible unit already has a primary resident or a pending registration pass.
           </AlertDescription>
         </Alert>
       ) : null}
@@ -393,7 +374,7 @@ export default function RegistrationPassesPage() {
                     <TableRow
                       key={invite.id}
                       tabIndex={0}
-                      className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                      className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                       onClick={() => setSelectedInvite(invite)}
                       onKeyDown={(event) =>
                         handleClickableRowKeyDown(event, () => setSelectedInvite(invite))
@@ -401,14 +382,14 @@ export default function RegistrationPassesPage() {
                     >
                       <TableCell>
                         <div className="space-y-1">
-                          <p className="font-medium">{invite.recipientName}</p>
+                          <p className="font-medium">
+                            {invite.recipientName ?? 'Unit registration link'}
+                          </p>
                           <p className="text-xs text-muted-foreground">
-                            {invite.recipientEmail}
+                            {invite.recipientEmail ?? 'Email collected at activation'}
                           </p>
                           {invite.recipientPhone ? (
-                            <p className="text-xs text-muted-foreground">
-                              {invite.recipientPhone}
-                            </p>
+                            <p className="text-xs text-muted-foreground">{invite.recipientPhone}</p>
                           ) : null}
                         </div>
                       </TableCell>
@@ -429,18 +410,19 @@ export default function RegistrationPassesPage() {
                             </p>
                           ) : null}
                           {invite.status === 'REVOKED' && invite.revokeReason ? (
-                            <p className="text-xs text-muted-foreground">
-                              {invite.revokeReason}
-                            </p>
+                            <p className="text-xs text-muted-foreground">{invite.revokeReason}</p>
                           ) : null}
                         </div>
                       </TableCell>
                       <TableCell>
                         <div className="space-y-1 text-sm">
-                          <p>{formatDistanceToNow(new Date(invite.expiresAt), { addSuffix: true })}</p>
+                          <p>
+                            {formatDistanceToNow(new Date(invite.expiresAt), { addSuffix: true })}
+                          </p>
                           {invite.sentAt ? (
                             <p className="text-xs text-muted-foreground">
-                              Sent {formatDistanceToNow(new Date(invite.sentAt), { addSuffix: true })}
+                              Sent{' '}
+                              {formatDistanceToNow(new Date(invite.sentAt), { addSuffix: true })}
                             </p>
                           ) : (
                             <p className="text-xs text-muted-foreground">Not emailed</p>
@@ -452,9 +434,7 @@ export default function RegistrationPassesPage() {
                           <p className="text-sm font-medium">
                             {invite.issuer.name || 'Unknown issuer'}
                           </p>
-                          <p className="text-xs text-muted-foreground">
-                            {invite.issuer.email}
-                          </p>
+                          <p className="text-xs text-muted-foreground">{invite.issuer.email}</p>
                         </div>
                       </TableCell>
                       <TableCell className="text-right">

--- a/src/app/(dashboard)/dashboard/units/page.tsx
+++ b/src/app/(dashboard)/dashboard/units/page.tsx
@@ -2,7 +2,20 @@
 
 import { useState, useCallback } from 'react';
 import { useFetchOnChange } from '@/hooks/use-fetch-on-change';
-import { Building2, Home, Phone, Mail, Search, Plus, Edit2, Trash2 } from 'lucide-react';
+import {
+  Building2,
+  CheckCircle2,
+  Copy,
+  Edit2,
+  Home,
+  Loader2,
+  Mail,
+  Phone,
+  Plus,
+  QrCode,
+  Search,
+  Trash2,
+} from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -62,6 +75,25 @@ interface Unit {
     id: string;
     name: string;
   };
+  residents: {
+    id: string;
+    name: string;
+    email: string | null;
+    createdAt: string;
+  }[];
+  residentInvites: {
+    id: string;
+    recipientName: string | null;
+    recipientEmail: string | null;
+    expiresAt: string;
+    consumedAt: string | null;
+    revokedAt: string | null;
+    resident: {
+      id: string;
+      name: string;
+      email: string | null;
+    } | null;
+  }[];
   _count: {
     parkingPasses: number;
     residents: number;
@@ -94,6 +126,7 @@ export default function UnitsPage() {
   const [selectedBuilding, setSelectedBuilding] = useState<string>('all');
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [editingUnit, setEditingUnit] = useState<Unit | null>(null);
+  const [generatingLinkUnitId, setGeneratingLinkUnitId] = useState<string | null>(null);
   const [formData, setFormData] = useState({
     unitNumber: '',
     floor: '',
@@ -173,9 +206,7 @@ export default function UnitsPage() {
         floor: formData.floor ? parseInt(formData.floor) : null,
       };
 
-      const url = editingUnit
-        ? `/api/units/manage?id=${editingUnit.id}`
-        : '/api/units/manage';
+      const url = editingUnit ? `/api/units/manage?id=${editingUnit.id}` : '/api/units/manage';
 
       const response = await fetch(url, {
         method: editingUnit ? 'PATCH' : 'POST',
@@ -216,21 +247,108 @@ export default function UnitsPage() {
     }
   };
 
+  const handleGenerateRegistrationLink = async (unit: Unit) => {
+    setGeneratingLinkUnitId(unit.id);
+
+    try {
+      const response = await fetch(`/api/units/${unit.id}/registration-link`, {
+        method: 'POST',
+      });
+      const data: {
+        registrationUrl?: string;
+        invite?: Unit['residentInvites'][number];
+        error?: string;
+      } = await response.json();
+
+      if (!response.ok || !data.registrationUrl) {
+        throw new Error(data.error || 'Failed to create registration link');
+      }
+
+      try {
+        await navigator.clipboard.writeText(data.registrationUrl);
+        toast.success('Registration link created and copied to clipboard');
+      } catch {
+        toast.success('Registration link created');
+        toast.error('Unable to copy the registration link');
+      }
+
+      if (data.invite) {
+        setEditingUnit((current) =>
+          current?.id === unit.id
+            ? { ...current, residentInvites: [data.invite as Unit['residentInvites'][number]] }
+            : current
+        );
+      }
+      await fetchUnits();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to create registration link');
+    } finally {
+      setGeneratingLinkUnitId(null);
+    }
+  };
+
+  const getRegistrationState = (unit: Unit) => {
+    const primaryResident = unit.residents[0] ?? null;
+    const latestInvite = unit.residentInvites[0] ?? null;
+
+    if (primaryResident) {
+      return {
+        label: 'Account activated',
+        description: `${primaryResident.name}${
+          primaryResident.email ? ` (${primaryResident.email})` : ''
+        }`,
+        variant: 'default' as const,
+        icon: CheckCircle2,
+      };
+    }
+
+    if (latestInvite?.consumedAt) {
+      const resident = latestInvite.resident;
+      return {
+        label: 'Account activated',
+        description: resident
+          ? `${resident.name}${resident.email ? ` (${resident.email})` : ''}`
+          : 'Registration completed',
+        variant: 'default' as const,
+        icon: CheckCircle2,
+      };
+    }
+
+    if (latestInvite) {
+      return {
+        label: 'Registration link pending',
+        description: `Expires ${new Date(latestInvite.expiresAt).toLocaleDateString()}`,
+        variant: 'outline' as const,
+        icon: QrCode,
+      };
+    }
+
+    return {
+      label: 'No registration link',
+      description: 'Generate a link from the actions column.',
+      variant: 'secondary' as const,
+      icon: QrCode,
+    };
+  };
+
   return (
     <div className="space-y-4 md:space-y-6">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">{t('title')}</h1>
-          <p className="text-sm md:text-base text-muted-foreground">{t('description')}</p>
+          <h1 className="text-2xl font-bold tracking-tight md:text-3xl">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground md:text-base">{t('description')}</p>
         </div>
-        <Button onClick={() => handleOpenDialog()} className="w-full md:w-auto min-h-[44px] md:min-h-0">
+        <Button
+          onClick={() => handleOpenDialog()}
+          className="min-h-[44px] w-full md:min-h-0 md:w-auto"
+        >
           <Plus className="mr-2 h-4 w-4" />
           {t('addUnit')}
         </Button>
       </div>
 
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-4">
-        <div className="relative w-full md:flex-1 md:max-w-sm">
+        <div className="relative w-full md:max-w-sm md:flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder={t('searchPlaceholder')}
@@ -239,7 +357,7 @@ export default function UnitsPage() {
               setPagination((current) => ({ ...current, page: 1 }));
               setSearch(e.target.value);
             }}
-            className="pl-9 h-11 md:h-10 text-base md:text-sm"
+            className="h-11 pl-9 text-base md:h-10 md:text-sm"
           />
         </div>
         <Select
@@ -249,7 +367,7 @@ export default function UnitsPage() {
             setSelectedBuilding(value);
           }}
         >
-          <SelectTrigger className="w-full md:w-[200px] h-11 md:h-10">
+          <SelectTrigger className="h-11 w-full md:h-10 md:w-[200px]">
             <SelectValue placeholder={t('filterBuilding')} />
           </SelectTrigger>
           <SelectContent>
@@ -296,7 +414,7 @@ export default function UnitsPage() {
                     <TableRow
                       key={unit.id}
                       tabIndex={0}
-                      className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                      className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                       onClick={() => handleOpenDialog(unit)}
                       onKeyDown={(event) =>
                         handleClickableRowKeyDown(event, () => handleOpenDialog(unit))
@@ -339,12 +457,14 @@ export default function UnitsPage() {
                             </div>
                           )}
                           {!unit.primaryEmail && !unit.primaryPhone && (
-                            <span className="text-muted-foreground text-xs">{t('noContact')}</span>
+                            <span className="text-xs text-muted-foreground">{t('noContact')}</span>
                           )}
                         </div>
                       </TableCell>
                       <TableCell>
-                        <Badge variant="outline">{t('passesCount', { count: unit._count.parkingPasses })}</Badge>
+                        <Badge variant="outline">
+                          {t('passesCount', { count: unit._count.parkingPasses })}
+                        </Badge>
                       </TableCell>
                       <TableCell>
                         <div className="flex flex-col gap-1">
@@ -354,10 +474,31 @@ export default function UnitsPage() {
                           <Badge variant={unit.isOccupied ? 'outline' : 'secondary'}>
                             {unit.isOccupied ? t('occupied') : t('vacant')}
                           </Badge>
+                          {unit.residents.length > 0 ? (
+                            <Badge variant="default">Account activated</Badge>
+                          ) : null}
                         </div>
                       </TableCell>
                       <TableCell className="text-right">
                         <div className="flex justify-end gap-2">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            title="Generate registration link"
+                            aria-label={`Generate registration link for unit ${unit.unitNumber}`}
+                            disabled={generatingLinkUnitId === unit.id || unit.residents.length > 0}
+                            onClick={(event) => {
+                              stopClickableRowPropagation(event);
+                              void handleGenerateRegistrationLink(unit);
+                            }}
+                            onKeyDown={stopClickableRowPropagation}
+                          >
+                            {generatingLinkUnitId === unit.id ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <QrCode className="h-4 w-4" />
+                            )}
+                          </Button>
                           <Button
                             variant="ghost"
                             size="icon"
@@ -432,7 +573,7 @@ export default function UnitsPage() {
                     id="unitNumber"
                     value={formData.unitNumber}
                     onChange={(e) => setFormData({ ...formData, unitNumber: e.target.value })}
-                    className="h-11 md:h-10 text-base md:text-sm"
+                    className="h-11 text-base md:h-10 md:text-sm"
                     required
                   />
                 </div>
@@ -443,7 +584,7 @@ export default function UnitsPage() {
                     type="number"
                     value={formData.floor}
                     onChange={(e) => setFormData({ ...formData, floor: e.target.value })}
-                    className="h-11 md:h-10 text-base md:text-sm"
+                    className="h-11 text-base md:h-10 md:text-sm"
                   />
                 </div>
               </div>
@@ -453,7 +594,7 @@ export default function UnitsPage() {
                   id="section"
                   value={formData.section}
                   onChange={(e) => setFormData({ ...formData, section: e.target.value })}
-                  className="h-11 md:h-10 text-base md:text-sm"
+                  className="h-11 text-base md:h-10 md:text-sm"
                   placeholder={t('sectionPlaceholder')}
                 />
               </div>
@@ -464,7 +605,7 @@ export default function UnitsPage() {
                   type="email"
                   value={formData.primaryEmail}
                   onChange={(e) => setFormData({ ...formData, primaryEmail: e.target.value })}
-                  className="h-11 md:h-10 text-base md:text-sm"
+                  className="h-11 text-base md:h-10 md:text-sm"
                 />
               </div>
               <div className="space-y-2">
@@ -474,7 +615,7 @@ export default function UnitsPage() {
                   type="tel"
                   value={formData.primaryPhone}
                   onChange={(e) => setFormData({ ...formData, primaryPhone: e.target.value })}
-                  className="h-11 md:h-10 text-base md:text-sm"
+                  className="h-11 text-base md:h-10 md:text-sm"
                 />
               </div>
               <div className="flex items-center justify-between py-2">
@@ -503,9 +644,57 @@ export default function UnitsPage() {
                   </Label>
                 </div>
               </div>
+              {editingUnit ? (
+                <div className="rounded-lg border bg-muted/20 p-4">
+                  {(() => {
+                    const registrationState = getRegistrationState(editingUnit);
+                    const StateIcon = registrationState.icon;
+
+                    return (
+                      <div className="space-y-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex items-start gap-2">
+                            <StateIcon className="mt-0.5 h-4 w-4 text-muted-foreground" />
+                            <div>
+                              <p className="text-sm font-medium">Resident registration</p>
+                              <p className="text-sm text-muted-foreground">
+                                {registrationState.description}
+                              </p>
+                            </div>
+                          </div>
+                          <Badge variant={registrationState.variant}>
+                            {registrationState.label}
+                          </Badge>
+                        </div>
+                        {editingUnit.residents.length === 0 ? (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            className="w-full"
+                            disabled={generatingLinkUnitId === editingUnit.id}
+                            onClick={() => void handleGenerateRegistrationLink(editingUnit)}
+                          >
+                            {generatingLinkUnitId === editingUnit.id ? (
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            ) : (
+                              <Copy className="mr-2 h-4 w-4" />
+                            )}
+                            Generate and copy registration link
+                          </Button>
+                        ) : null}
+                      </div>
+                    );
+                  })()}
+                </div>
+              ) : null}
             </div>
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)} className="min-h-[44px] md:min-h-0">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setIsDialogOpen(false)}
+                className="min-h-[44px] md:min-h-0"
+              >
                 {tc('cancel')}
               </Button>
               <Button type="submit" className="min-h-[44px] md:min-h-0">

--- a/src/app/api/resident-invites/__tests__/route.test.ts
+++ b/src/app/api/resident-invites/__tests__/route.test.ts
@@ -80,6 +80,8 @@ describe('Resident invite API routes', () => {
       search: 'alina',
       buildingId: 'building-1',
       status: 'PENDING',
+      page: 1,
+      limit: 10,
     });
   });
 
@@ -206,6 +208,8 @@ describe('Resident invite API routes', () => {
     expect(data.buildingSlug).toBe('alina-visitor-parking');
     expect(mockConsumeResidentInvite).toHaveBeenCalledWith({
       token: 'token-1',
+      recipientName: undefined,
+      recipientEmail: undefined,
       password: 'Resident@123!',
       hasVehicle: true,
       strataLotNumber: '123',
@@ -238,6 +242,44 @@ describe('Resident invite API routes', () => {
     expect(response.status).toBe(200);
     expect(mockConsumeResidentInvite).toHaveBeenCalledWith({
       token: 'token-2',
+      recipientName: undefined,
+      recipientEmail: undefined,
+      password: 'Resident@123!',
+      hasVehicle: false,
+      strataLotNumber: '123',
+      assignedStallNumbers: ['12'],
+      personalLicensePlates: [],
+      ipAddress: null,
+      userAgent: null,
+    });
+  });
+
+  it('consumes a unit registration link with resident-entered contact details', async () => {
+    mockConsumeResidentInvite.mockResolvedValue({
+      buildingSlug: 'alina-visitor-parking',
+      unitNumber: '101',
+    });
+
+    const request = createMockPostRequest('http://localhost:3000/api/resident-invites/consume', {
+      token: 'token-5',
+      recipientName: 'Manual Resident',
+      recipientEmail: 'manual@example.com',
+      password: 'Resident@123!',
+      hasVehicle: false,
+      strataLotNumber: '123',
+      assignedStallNumbers: ['12'],
+      personalLicensePlates: [],
+      privacyConsent: true,
+      privacyPolicyVersion: '2026-04-02',
+    });
+
+    const response = await consumePOST(request);
+
+    expect(response.status).toBe(200);
+    expect(mockConsumeResidentInvite).toHaveBeenCalledWith({
+      token: 'token-5',
+      recipientName: 'Manual Resident',
+      recipientEmail: 'manual@example.com',
       password: 'Resident@123!',
       hasVehicle: false,
       strataLotNumber: '123',

--- a/src/app/api/resident-invites/consume/route.ts
+++ b/src/app/api/resident-invites/consume/route.ts
@@ -12,6 +12,8 @@ import {
 const consumeSchema = z
   .object({
     token: z.string().min(1),
+    recipientName: z.string().trim().min(1, 'Resident name is required').max(100).optional(),
+    recipientEmail: z.string().trim().email('A valid email is required').optional(),
     password: strongPasswordSchema,
     hasVehicle: z.boolean(),
     strataLotNumber: residentStrataLotSchema,
@@ -62,6 +64,8 @@ export async function POST(request: NextRequest) {
 
     const result = await consumeResidentInvite({
       token: data.token,
+      recipientName: data.recipientName,
+      recipientEmail: data.recipientEmail,
       password: data.password,
       hasVehicle: data.hasVehicle,
       strataLotNumber: data.strataLotNumber,

--- a/src/app/api/units/[id]/registration-link/route.ts
+++ b/src/app/api/units/[id]/registration-link/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requirePermission } from '@/lib/api-auth';
+import {
+  createUnitRegistrationLink,
+  ResidentInviteError,
+} from '@/services/resident-invite-service';
+
+export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const authResult = await requirePermission('resident_invites:manage');
+    if (!authResult.authorized) {
+      return authResult.response;
+    }
+
+    const { id } = await params;
+    const result = await createUnitRegistrationLink({
+      issuerId: authResult.request.userId,
+      issuerRole: authResult.request.role,
+      unitId: id,
+    });
+
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    if (error instanceof ResidentInviteError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.status }
+      );
+    }
+
+    console.error('Error creating unit registration link:', error);
+    return NextResponse.json({ error: 'Failed to create registration link' }, { status: 500 });
+  }
+}

--- a/src/app/api/units/manage/route.ts
+++ b/src/app/api/units/manage/route.ts
@@ -30,6 +30,7 @@ export async function GET(request: NextRequest) {
     const page = Number.isFinite(parsedPage) ? Math.max(1, parsedPage) : 1;
     const limit = Number.isFinite(parsedLimit) ? Math.min(100, Math.max(1, parsedLimit)) : 10;
     const skip = (page - 1) * limit;
+    const now = new Date();
 
     const where: Record<string, unknown> = {
       deletedAt: null,
@@ -63,11 +64,51 @@ export async function GET(request: NextRequest) {
               residents: true,
             },
           },
+          residents: {
+            where: {
+              isPrimary: true,
+              isActive: true,
+              deletedAt: null,
+            },
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              createdAt: true,
+            },
+            take: 1,
+          },
+          residentInvites: {
+            where: {
+              revokedAt: null,
+              OR: [
+                { consumedAt: { not: null } },
+                {
+                  consumedAt: null,
+                  expiresAt: { gt: now },
+                },
+              ],
+            },
+            select: {
+              id: true,
+              recipientName: true,
+              recipientEmail: true,
+              expiresAt: true,
+              consumedAt: true,
+              revokedAt: true,
+              resident: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                },
+              },
+            },
+            orderBy: { createdAt: 'desc' },
+            take: 1,
+          },
         },
-        orderBy: [
-          { building: { name: 'asc' } },
-          { unitNumber: 'asc' },
-        ],
+        orderBy: [{ building: { name: 'asc' } }, { unitNumber: 'asc' }],
         skip,
         take: limit,
       }),
@@ -91,10 +132,7 @@ export async function GET(request: NextRequest) {
     });
   } catch (error) {
     console.error('Error fetching units:', error);
-    return NextResponse.json(
-      { error: 'Failed to fetch units' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to fetch units' }, { status: 500 });
   }
 }
 
@@ -164,15 +202,12 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     if (error instanceof z.ZodError) {
       return NextResponse.json(
-        { error: error.errors[0]?.message || "Validation error" },
+        { error: error.errors[0]?.message || 'Validation error' },
         { status: 400 }
       );
     }
     console.error('Error creating unit:', error);
-    return NextResponse.json(
-      { error: 'Failed to create unit' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to create unit' }, { status: 500 });
   }
 }
 
@@ -229,8 +264,10 @@ export async function PATCH(request: NextRequest) {
     if (validatedData.unitNumber !== undefined) updateData.unitNumber = validatedData.unitNumber;
     if (validatedData.floor !== undefined) updateData.floor = validatedData.floor;
     if (validatedData.section !== undefined) updateData.section = validatedData.section;
-    if (validatedData.primaryPhone !== undefined) updateData.primaryPhone = validatedData.primaryPhone;
-    if (validatedData.primaryEmail !== undefined) updateData.primaryEmail = validatedData.primaryEmail || null;
+    if (validatedData.primaryPhone !== undefined)
+      updateData.primaryPhone = validatedData.primaryPhone;
+    if (validatedData.primaryEmail !== undefined)
+      updateData.primaryEmail = validatedData.primaryEmail || null;
     if (validatedData.buildingId !== undefined) updateData.buildingId = validatedData.buildingId;
     if (validatedData.isOccupied !== undefined) updateData.isOccupied = validatedData.isOccupied;
     if (validatedData.isActive !== undefined) updateData.isActive = validatedData.isActive;
@@ -262,15 +299,12 @@ export async function PATCH(request: NextRequest) {
   } catch (error) {
     if (error instanceof z.ZodError) {
       return NextResponse.json(
-        { error: error.errors[0]?.message || "Validation error" },
+        { error: error.errors[0]?.message || 'Validation error' },
         { status: 400 }
       );
     }
     console.error('Error updating unit:', error);
-    return NextResponse.json(
-      { error: 'Failed to update unit' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to update unit' }, { status: 500 });
   }
 }
 
@@ -318,9 +352,6 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error deleting unit:', error);
-    return NextResponse.json(
-      { error: 'Failed to delete unit' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'Failed to delete unit' }, { status: 500 });
   }
 }

--- a/src/components/dashboard/resident-invite-details-sheet.tsx
+++ b/src/components/dashboard/resident-invite-details-sheet.tsx
@@ -27,7 +27,9 @@ export function ResidentInviteDetailsSheet({
         <SheetHeader>
           <SheetTitle>Registration Pass Details</SheetTitle>
           <SheetDescription>
-            {invite ? `Onboarding link for ${invite.recipientName}` : 'Registration pass'}
+            {invite
+              ? `Onboarding link for ${invite.recipientName ?? `unit ${invite.unit.unitNumber}`}`
+              : 'Registration pass'}
           </SheetDescription>
         </SheetHeader>
 
@@ -36,8 +38,12 @@ export function ResidentInviteDetailsSheet({
             <div className="rounded-lg border bg-muted/20 p-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="text-lg font-semibold">{invite.recipientName}</p>
-                  <p className="text-sm text-muted-foreground">{invite.recipientEmail}</p>
+                  <p className="text-lg font-semibold">
+                    {invite.recipientName ?? 'Unit registration link'}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {invite.recipientEmail ?? 'Resident will enter email during activation'}
+                  </p>
                 </div>
                 <Badge>{invite.status}</Badge>
               </div>

--- a/src/components/dashboard/resident-invite-shared.ts
+++ b/src/components/dashboard/resident-invite-shared.ts
@@ -1,8 +1,4 @@
-export type ResidentInviteStatus =
-  | 'PENDING'
-  | 'EXPIRED'
-  | 'REVOKED'
-  | 'CONSUMED';
+export type ResidentInviteStatus = 'PENDING' | 'EXPIRED' | 'REVOKED' | 'CONSUMED';
 
 export interface ResidentInviteBuildingOption {
   id: string;
@@ -22,8 +18,8 @@ export interface ResidentInviteUnitOption {
 
 export interface ResidentInviteSummary {
   id: string;
-  recipientName: string;
-  recipientEmail: string;
+  recipientName: string | null;
+  recipientEmail: string | null;
   recipientPhone: string | null;
   status: ResidentInviteStatus;
   createdAt: string;

--- a/src/components/dashboard/revoke-resident-invite-dialog.tsx
+++ b/src/components/dashboard/revoke-resident-invite-dialog.tsx
@@ -65,9 +65,7 @@ export function RevokeResidentInviteDialog({
       onOpenChange(false);
     } catch (submitError) {
       setError(
-        submitError instanceof Error
-          ? submitError.message
-          : 'Failed to revoke registration pass'
+        submitError instanceof Error ? submitError.message : 'Failed to revoke registration pass'
       );
     } finally {
       setIsSubmitting(false);
@@ -81,7 +79,9 @@ export function RevokeResidentInviteDialog({
           <DialogTitle>Revoke Registration Pass</DialogTitle>
           <DialogDescription>
             {invite
-              ? `Revoke the registration link for ${invite.recipientName} in unit ${invite.unit.unitNumber}.`
+              ? `Revoke the registration link for ${
+                  invite.recipientName ?? `unit ${invite.unit.unitNumber}`
+                }.`
               : 'Revoke this registration pass.'}
           </DialogDescription>
         </DialogHeader>

--- a/src/components/registration/resident-invite-registration-form.tsx
+++ b/src/components/registration/resident-invite-registration-form.tsx
@@ -37,8 +37,8 @@ import { LICENSE_PLATE_CONFIG } from '@/lib/constants';
 interface ResidentInvitePreview {
   id: string;
   status: ResidentInviteStatus;
-  recipientName: string;
-  recipientEmail: string;
+  recipientName: string | null;
+  recipientEmail: string | null;
   recipientPhone: string | null;
   expiresAt: string;
   createdAt: string;
@@ -97,6 +97,8 @@ export function ResidentInviteRegistrationForm({
   invite,
 }: ResidentInviteRegistrationFormProps) {
   const router = useRouter();
+  const [recipientName, setRecipientName] = useState(invite?.recipientName ?? '');
+  const [recipientEmail, setRecipientEmail] = useState(invite?.recipientEmail ?? '');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [strataLotNumber, setStrataLotNumber] = useState('');
@@ -112,11 +114,16 @@ export function ResidentInviteRegistrationForm({
   const [strataLotTouched, setStrataLotTouched] = useState(false);
   const [assignedStallTouched, setAssignedStallTouched] = useState<boolean[]>([false]);
   const [licensePlateTouched, setLicensePlateTouched] = useState<boolean[]>([false]);
+  const [recipientNameTouched, setRecipientNameTouched] = useState(false);
+  const [recipientEmailTouched, setRecipientEmailTouched] = useState(false);
   const [passwordTouched, setPasswordTouched] = useState(false);
   const [confirmPasswordTouched, setConfirmPasswordTouched] = useState(false);
   const policyScrollRef = useRef<HTMLDivElement>(null);
 
   const blockedContent = useMemo(() => getBlockedMessage(invite), [invite]);
+  const requiresRecipientDetails = !invite?.recipientEmail || !invite?.recipientName;
+  const cleanedRecipientName = recipientName.trim();
+  const cleanedRecipientEmail = recipientEmail.trim().toLowerCase();
 
   const cleanedStrataLotNumber = strataLotNumber.trim();
   const cleanedAssignedStallNumbers = assignedStallNumbers.map((stallNumber) => stallNumber.trim());
@@ -146,15 +153,26 @@ export function ResidentInviteRegistrationForm({
     : [];
   const hasLicensePlateErrors = licensePlateErrors.some(Boolean);
   const passwordError = getPasswordValidationError(password);
+  const recipientNameError =
+    requiresRecipientDetails && !cleanedRecipientName ? 'Resident name is required.' : null;
+  const recipientEmailError =
+    requiresRecipientDetails && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(cleanedRecipientEmail)
+      ? 'A valid email is required.'
+      : null;
   const confirmPasswordError =
     confirmPassword.length > 0 && password !== confirmPassword ? 'Passwords do not match.' : null;
   const showStrataLotError = Boolean(strataLotError && (hasAttemptedSubmit || strataLotTouched));
-  const showAssignedStallErrors = assignedStallErrors.map(
-    (stallError, index) => Boolean(stallError && (hasAttemptedSubmit || assignedStallTouched[index]))
+  const showRecipientNameError = Boolean(
+    recipientNameError && (hasAttemptedSubmit || recipientNameTouched)
   );
-  const showLicensePlateErrors = licensePlateErrors.map(
-    (licensePlateError, index) =>
-      Boolean(licensePlateError && (hasAttemptedSubmit || licensePlateTouched[index]))
+  const showRecipientEmailError = Boolean(
+    recipientEmailError && (hasAttemptedSubmit || recipientEmailTouched)
+  );
+  const showAssignedStallErrors = assignedStallErrors.map((stallError, index) =>
+    Boolean(stallError && (hasAttemptedSubmit || assignedStallTouched[index]))
+  );
+  const showLicensePlateErrors = licensePlateErrors.map((licensePlateError, index) =>
+    Boolean(licensePlateError && (hasAttemptedSubmit || licensePlateTouched[index]))
   );
   const showPasswordError = Boolean(passwordError && (hasAttemptedSubmit || passwordTouched));
   const showConfirmPasswordError = Boolean(
@@ -163,6 +181,8 @@ export function ResidentInviteRegistrationForm({
 
   const canSubmit =
     !isSubmitting &&
+    !recipientNameError &&
+    !recipientEmailError &&
     !strataLotError &&
     cleanedAssignedStallNumbers.length > 0 &&
     !hasAssignedStallErrors &&
@@ -229,6 +249,16 @@ export function ResidentInviteRegistrationForm({
     setError(null);
     setHasAttemptedSubmit(true);
 
+    if (recipientNameError) {
+      setError(recipientNameError);
+      return;
+    }
+
+    if (recipientEmailError) {
+      setError(recipientEmailError);
+      return;
+    }
+
     if (strataLotError) {
       setError(strataLotError);
       return;
@@ -276,6 +306,8 @@ export function ResidentInviteRegistrationForm({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           token,
+          recipientName: requiresRecipientDetails ? cleanedRecipientName : undefined,
+          recipientEmail: requiresRecipientDetails ? cleanedRecipientEmail : undefined,
           password,
           hasVehicle,
           strataLotNumber: cleanedStrataLotNumber,
@@ -354,8 +386,14 @@ export function ResidentInviteRegistrationForm({
         ) : null}
 
         <div className="rounded-lg bg-muted/40 p-4 text-sm">
-          <p className="font-medium">{invite.recipientName}</p>
-          <p className="text-muted-foreground">{invite.recipientEmail}</p>
+          <p className="font-medium">{invite.recipientName ?? 'Unit registration link'}</p>
+          {invite.recipientEmail ? (
+            <p className="text-muted-foreground">{invite.recipientEmail}</p>
+          ) : (
+            <p className="text-muted-foreground">
+              Enter your name and email to activate this unit.
+            </p>
+          )}
           <p className="mt-2 text-xs text-muted-foreground">
             This one-time link expires{' '}
             {formatDistanceToNow(new Date(invite.expiresAt), { addSuffix: true })}.
@@ -363,6 +401,42 @@ export function ResidentInviteRegistrationForm({
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+          {requiresRecipientDetails ? (
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="resident-registration-name">Full Name</Label>
+                <Input
+                  id="resident-registration-name"
+                  value={recipientName}
+                  onChange={(event) => setRecipientName(event.target.value)}
+                  onBlur={() => setRecipientNameTouched(true)}
+                  className="h-11 md:h-10"
+                  autoComplete="name"
+                  required
+                />
+                {showRecipientNameError && (
+                  <p className="text-sm text-destructive">{recipientNameError}</p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="resident-registration-email">Email</Label>
+                <Input
+                  id="resident-registration-email"
+                  type="email"
+                  value={recipientEmail}
+                  onChange={(event) => setRecipientEmail(event.target.value)}
+                  onBlur={() => setRecipientEmailTouched(true)}
+                  className="h-11 md:h-10"
+                  autoComplete="email"
+                  required
+                />
+                {showRecipientEmailError && (
+                  <p className="text-sm text-destructive">{recipientEmailError}</p>
+                )}
+              </div>
+            </div>
+          ) : null}
+
           <div className="space-y-2">
             <Label htmlFor="resident-registration-strata-lot">Strata Lot #</Label>
             <Input

--- a/src/services/resident-invite-service.ts
+++ b/src/services/resident-invite-service.ts
@@ -17,8 +17,8 @@ export type ResidentInviteStatus = 'PENDING' | 'EXPIRED' | 'REVOKED' | 'CONSUMED
 
 export interface ResidentInviteSummary {
   id: string;
-  recipientName: string;
-  recipientEmail: string;
+  recipientName: string | null;
+  recipientEmail: string | null;
   recipientPhone: string | null;
   status: ResidentInviteStatus;
   createdAt: string;
@@ -71,8 +71,8 @@ export interface ResidentInviteUnitOption {
 export interface ResidentInvitePreview {
   id: string;
   status: ResidentInviteStatus;
-  recipientName: string;
-  recipientEmail: string;
+  recipientName: string | null;
+  recipientEmail: string | null;
   recipientPhone: string | null;
   expiresAt: string;
   createdAt: string;
@@ -116,6 +116,12 @@ interface CreateResidentInviteInput {
   recipientPhone?: string | undefined;
 }
 
+interface CreateUnitRegistrationLinkInput {
+  issuerId: string;
+  issuerRole: UserRole;
+  unitId: string;
+}
+
 interface RevokeResidentInviteInput {
   issuerId: string;
   issuerRole: UserRole;
@@ -131,6 +137,8 @@ interface ReissueResidentInviteInput {
 
 interface ConsumeResidentInviteInput {
   token: string;
+  recipientName?: string | undefined;
+  recipientEmail?: string | undefined;
   password: string;
   hasVehicle: boolean;
   strataLotNumber: string;
@@ -268,10 +276,11 @@ async function assertInviteEligibility(
   client: ScopedClient,
   buildingId: string,
   unitId: string,
-  recipientEmail: string,
+  recipientEmail?: string | null,
   ignoreInviteId?: string
 ) {
   const now = new Date();
+  const emailFilter = recipientEmail ? normalizeEmail(recipientEmail) : null;
 
   const [building, unit, activePrimaryResident, existingUser, existingResident, existingInvite] =
     await Promise.all([
@@ -309,27 +318,31 @@ async function assertInviteEligibility(
         },
         select: { id: true },
       }),
-      client.user.findFirst({
-        where: {
-          email: recipientEmail,
-          deletedAt: null,
-        },
-        select: { id: true },
-      }),
-      client.resident.findFirst({
-        where: {
-          email: recipientEmail,
-          deletedAt: null,
-        },
-        select: { id: true },
-      }),
+      emailFilter
+        ? client.user.findFirst({
+            where: {
+              email: emailFilter,
+              deletedAt: null,
+            },
+            select: { id: true },
+          })
+        : Promise.resolve(null),
+      emailFilter
+        ? client.resident.findFirst({
+            where: {
+              email: emailFilter,
+              deletedAt: null,
+            },
+            select: { id: true },
+          })
+        : Promise.resolve(null),
       client.residentInvite.findFirst({
         where: {
           ...(ignoreInviteId ? { id: { not: ignoreInviteId } } : {}),
           consumedAt: null,
           revokedAt: null,
           expiresAt: { gt: now },
-          OR: [{ unitId }, { recipientEmail }],
+          OR: emailFilter ? [{ unitId }, { recipientEmail: emailFilter }] : [{ unitId }],
         },
         select: {
           id: true,
@@ -384,8 +397,8 @@ async function assertInviteEligibility(
 
 function formatResidentInvite(invite: {
   id: string;
-  recipientName: string;
-  recipientEmail: string;
+  recipientName: string | null;
+  recipientEmail: string | null;
   recipientPhone: string | null;
   createdAt: Date;
   expiresAt: Date;
@@ -448,9 +461,7 @@ export async function listResidentInvites(params: {
 }): Promise<ResidentInviteListResult> {
   const { userId, role, search, buildingId, status } = params;
   const page = Number.isFinite(params.page) ? Math.max(1, params.page ?? 1) : 1;
-  const limit = Number.isFinite(params.limit)
-    ? Math.min(100, Math.max(1, params.limit ?? 10))
-    : 10;
+  const limit = Number.isFinite(params.limit) ? Math.min(100, Math.max(1, params.limit ?? 10)) : 10;
 
   const accessibleBuildingIds = await getAccessibleBuildingIds(prisma, userId, role);
   if (buildingId) {
@@ -690,6 +701,95 @@ export async function createResidentInvite(
     }),
     registrationUrl,
     emailSent,
+  };
+}
+
+export async function createUnitRegistrationLink(
+  input: CreateUnitRegistrationLinkInput
+): Promise<ResidentInviteMutationResult> {
+  const token = createResidentInviteToken();
+  const tokenHash = hashResidentInviteToken(token);
+
+  const invite = await prisma.$transaction(async (tx) => {
+    const unit = await tx.unit.findFirst({
+      where: {
+        id: input.unitId,
+        isActive: true,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        buildingId: true,
+      },
+    });
+
+    if (!unit) {
+      throw new ResidentInviteError('Unit not found', 404, 'UNIT_NOT_FOUND');
+    }
+
+    await requireInviteScope(tx, input.issuerId, input.issuerRole, unit.buildingId);
+    const { building } = await assertInviteEligibility(tx, unit.buildingId, unit.id, null);
+
+    const createdInvite = await tx.residentInvite.create({
+      data: {
+        issuerId: input.issuerId,
+        buildingId: building.id,
+        unitId: unit.id,
+        recipientName: null,
+        recipientEmail: null,
+        recipientPhone: null,
+        tokenHash,
+        expiresAt: new Date(Date.now() + 72 * 60 * 60 * 1000),
+      },
+      include: {
+        building: {
+          select: {
+            id: true,
+            name: true,
+            slug: true,
+          },
+        },
+        unit: {
+          select: {
+            id: true,
+            unitNumber: true,
+          },
+        },
+        issuer: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
+
+    await tx.auditLog.create({
+      data: {
+        action: 'ISSUE_RESIDENT_INVITE',
+        entityType: 'ResidentInvite',
+        entityId: createdInvite.id,
+        userId: input.issuerId,
+        details: {
+          buildingId: building.id,
+          unitId: unit.id,
+          delivery: 'MANUAL_LINK',
+        },
+      },
+    });
+
+    return createdInvite;
+  });
+
+  return {
+    invite: formatResidentInvite({
+      ...invite,
+      resident: null,
+      user: null,
+    }),
+    registrationUrl: buildRegistrationUrl(token),
+    emailSent: false,
   };
 }
 
@@ -934,15 +1034,18 @@ export async function reissueResidentInvite(
   });
 
   const registrationUrl = buildRegistrationUrl(token);
-  const emailSent = await sendResidentInviteEmail({
-    inviteId: invite.id,
-    recipientEmail: invite.recipientEmail,
-    recipientName: invite.recipientName,
-    buildingName: invite.building.name,
-    unitNumber: invite.unit.unitNumber,
-    registrationUrl,
-    expiresAt: invite.expiresAt,
-  });
+  const emailSent =
+    invite.recipientEmail && invite.recipientName
+      ? await sendResidentInviteEmail({
+          inviteId: invite.id,
+          recipientEmail: invite.recipientEmail,
+          recipientName: invite.recipientName,
+          buildingName: invite.building.name,
+          unitNumber: invite.unit.unitNumber,
+          registrationUrl,
+          expiresAt: invite.expiresAt,
+        })
+      : false;
 
   let sentAt = invite.sentAt;
   if (emailSent) {
@@ -1018,6 +1121,8 @@ export async function consumeResidentInvite(input: ConsumeResidentInviteInput): 
   buildingSlug: string;
   unitNumber: string;
 }> {
+  const inputRecipientName = input.recipientName?.trim() || null;
+  const inputRecipientEmail = input.recipientEmail ? normalizeEmail(input.recipientEmail) : null;
   const strataLotNumber = input.strataLotNumber.trim();
   const assignedStallNumbers = input.assignedStallNumbers
     .map((stallNumber) => stallNumber.trim())
@@ -1074,6 +1179,10 @@ export async function consumeResidentInvite(input: ConsumeResidentInviteInput): 
   const passwordError = getPasswordValidationError(input.password);
   if (passwordError) {
     throw new ResidentInviteError(passwordError.replace(/\.$/, ''), 400, 'PASSWORD_INVALID');
+  }
+
+  if (input.recipientEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(inputRecipientEmail ?? '')) {
+    throw new ResidentInviteError('A valid email is required', 400, 'EMAIL_INVALID');
   }
 
   const uniqueAssignedStallNumbers = Array.from(new Set(assignedStallNumbers));
@@ -1184,11 +1293,22 @@ export async function consumeResidentInvite(input: ConsumeResidentInviteInput): 
         );
       }
 
+      const recipientName = currentInvite.recipientName ?? inputRecipientName;
+      const recipientEmail = currentInvite.recipientEmail ?? inputRecipientEmail;
+
+      if (!recipientName) {
+        throw new ResidentInviteError('Resident name is required', 400, 'RECIPIENT_NAME_REQUIRED');
+      }
+
+      if (!recipientEmail) {
+        throw new ResidentInviteError('A valid email is required', 400, 'RECIPIENT_EMAIL_REQUIRED');
+      }
+
       await assertInviteEligibility(
         tx,
         currentInvite.buildingId,
         currentInvite.unitId,
-        currentInvite.recipientEmail,
+        recipientEmail,
         currentInvite.id
       );
 
@@ -1218,8 +1338,8 @@ export async function consumeResidentInvite(input: ConsumeResidentInviteInput): 
 
       const user = await tx.user.create({
         data: {
-          email: currentInvite.recipientEmail,
-          name: currentInvite.recipientName,
+          email: recipientEmail,
+          name: recipientName,
           passwordHash: null,
           role: 'RESIDENT',
           emailVerified: new Date(),
@@ -1229,8 +1349,8 @@ export async function consumeResidentInvite(input: ConsumeResidentInviteInput): 
 
       const resident = await tx.resident.create({
         data: {
-          name: currentInvite.recipientName,
-          email: currentInvite.recipientEmail,
+          name: recipientName,
+          email: recipientEmail,
           phone: currentInvite.recipientPhone,
           strataLotNumber,
           assignedStallNumbers: uniqueAssignedStallNumbers,
@@ -1273,6 +1393,8 @@ export async function consumeResidentInvite(input: ConsumeResidentInviteInput): 
       await tx.residentInvite.update({
         where: { id: currentInvite.id },
         data: {
+          recipientName,
+          recipientEmail,
           consumedAt: new Date(),
           consumedIp: input.ipAddress ?? null,
           consumedUserAgent: input.userAgent ?? null,


### PR DESCRIPTION
## Summary
Adds a unit-scoped resident registration link flow that does not require staff to enter a resident email before generating the registration link.

## What changed
- Added support for resident invites with nullable `recipientName` and `recipientEmail`.
- Added Prisma migration `20260428143000_optional_resident_invite_recipient`.
- Added `POST /api/units/[id]/registration-link` for generating a one-time registration link from a unit.
- Updated `/dashboard/units` actions with a QR/link button that generates the unit registration link and copies it to clipboard.
- Added resident registration status details to the Edit Unit dialog.
- Added an `Account activated` chip in the units table when a unit has an active primary resident.
- Updated resident registration so no-email unit links collect resident name and email during activation.
- Updated registration pass list/details/revoke UI to handle pending unit links without prefilled recipient details.
- Added/updated tests for consuming unit registration links with resident-entered contact details.

## Database
- Allows `resident_invites.recipientName` and `resident_invites.recipientEmail` to be nullable.
- Migration was applied successfully to the configured database.

## Validation
- `pnpm type-check`
- `pnpm test src/app/api/resident-invites/__tests__/route.test.ts src/components/registration/__tests__/resident-invite-registration-form.test.tsx`
- `pnpm prisma validate`
- `pnpm lint`

Note: `pnpm lint` passes with existing unrelated warnings.