### PR TITLE
Enforce downstream staff role creation

### DIFF
--- a/docs/roles-and-access.md
+++ b/docs/roles-and-access.md
@@ -1,0 +1,111 @@
+# Roles and Access Model
+
+This application uses role-based access control for staff and residents. The roles below already exist in the database enum and application permission map.
+
+## Role hierarchy
+
+From highest to lowest:
+
+1. `SUPER_ADMIN`
+2. `ADMIN`
+3. `MANAGER`
+4. `SECURITY`
+5. `RESIDENT`
+
+Staff account creation and role changes follow a downstream rule:
+
+- `SUPER_ADMIN` can create and assign all staff roles, including another `SUPER_ADMIN`.
+- `ADMIN` can create and assign `MANAGER` and `SECURITY`.
+- `MANAGER` can create and assign `SECURITY`.
+- `SECURITY` cannot create staff accounts.
+- `RESIDENT` accounts are not created from the staff users menu. They are created through resident registration passes.
+
+## Role responsibilities
+
+### Super Admin
+
+System owner role for the organization or application operator.
+
+Primary responsibilities:
+
+- Manage every staff role, including other super admins.
+- Manage users, buildings, units, parking rules, settings, and system health.
+- View analytics, reports, audit-sensitive operational data, passes, vehicles, and violations.
+- Issue and manage resident registration passes.
+
+Use this role sparingly. It can change system-level behavior and create top-level accounts.
+
+### Admin
+
+Property or organization administrator role.
+
+Primary responsibilities:
+
+- Manage downstream staff accounts, such as managers and security.
+- Manage buildings, units, parking rules, active passes, vehicles, violations, analytics, and reports.
+- View system health.
+
+Restrictions:
+
+- Cannot create, edit, suspend, delete, or promote users to `SUPER_ADMIN` or `ADMIN`.
+- Does not have the `system:admin` permission.
+
+### Manager
+
+Building operations role for day-to-day parking administration.
+
+Primary responsibilities:
+
+- Manage visitor and resident parking operations.
+- View and update passes, violations, vehicles, units, analytics, and reports.
+- Issue and manage resident registration passes.
+- Create downstream security accounts when needed.
+
+Restrictions:
+
+- Cannot manage admin or super admin accounts.
+- Cannot manage application settings or system health.
+
+### Security
+
+Patrol and enforcement role.
+
+Primary responsibilities:
+
+- View passes and vehicles.
+- View and create violations.
+- Use patrol workflows needed for parking enforcement.
+
+Restrictions:
+
+- Cannot create staff accounts.
+- Cannot manage users, settings, buildings, units, resident registration passes, analytics, or reports.
+- Cannot delete or administratively modify passes.
+
+### Resident
+
+Resident self-service role.
+
+Primary responsibilities:
+
+- View and create their own visitor passes.
+- Manage their own guests and vehicles.
+- Send visitor pass links.
+- View their own resident activity.
+
+Restrictions:
+
+- Cannot access staff user management.
+- Cannot be created from the generic staff users endpoint.
+- Resident account setup is handled through registration passes.
+
+## Why keep Admin and Security?
+
+The four staff roles are valid for this application because parking operations usually need separation of duties:
+
+- `SUPER_ADMIN` protects system ownership and top-level account creation.
+- `ADMIN` supports property administration without allowing peer or owner-level privilege escalation.
+- `MANAGER` supports building-level operations and resident onboarding.
+- `SECURITY` supports patrol and enforcement without access to configuration or user administration.
+
+This keeps sensitive actions limited while still allowing on-site teams to do their daily work.

--- a/src/app/(dashboard)/dashboard/users/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/page.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/components/ui/select';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
+import { useSession } from 'next-auth/react';
 import {
   handleClickableRowKeyDown,
   stopClickableRowPropagation,
@@ -43,6 +44,13 @@ import { ListPagination, type ListPaginationState } from '@/components/dashboard
 import { useTranslations } from 'next-intl';
 
 const DEFAULT_PAGE_SIZE = 10;
+const STAFF_ROLE_ORDER = ['SUPER_ADMIN', 'ADMIN', 'MANAGER', 'SECURITY'] as const;
+const ROLE_RANK: Record<(typeof STAFF_ROLE_ORDER)[number], number> = {
+  SUPER_ADMIN: 4,
+  ADMIN: 3,
+  MANAGER: 2,
+  SECURITY: 1,
+};
 
 interface User {
   id: string;
@@ -72,12 +80,32 @@ function UsersLoading() {
 export default function UsersPage() {
   const t = useTranslations('dashboard.usersPage');
   const tc = useTranslations('common');
+  const { data: session } = useSession();
+  const currentRole = session?.user?.role;
   const roleLabels: Record<string, { label: string; color: string }> = {
     SUPER_ADMIN: { label: t('superAdmin'), color: 'destructive' },
     ADMIN: { label: t('admin'), color: 'default' },
     MANAGER: { label: t('manager'), color: 'secondary' },
     SECURITY: { label: t('security'), color: 'outline' },
   };
+  const assignableRoles =
+    currentRole === 'SUPER_ADMIN'
+      ? STAFF_ROLE_ORDER
+      : STAFF_ROLE_ORDER.filter(
+          (role) =>
+            currentRole &&
+            currentRole in ROLE_RANK &&
+            ROLE_RANK[role] < ROLE_RANK[currentRole as keyof typeof ROLE_RANK]
+        );
+  const defaultRole = assignableRoles.includes('MANAGER')
+    ? 'MANAGER'
+    : (assignableRoles[0] ?? 'SECURITY');
+  const canManageRole = (role: string) =>
+    currentRole === 'SUPER_ADMIN' ||
+    (currentRole &&
+      currentRole in ROLE_RANK &&
+      role in ROLE_RANK &&
+      ROLE_RANK[role as keyof typeof ROLE_RANK] < ROLE_RANK[currentRole as keyof typeof ROLE_RANK]);
   const [users, setUsers] = useState<User[]>([]);
   const [pagination, setPagination] = useState<ListPaginationState>({
     page: 1,
@@ -141,7 +169,7 @@ export default function UsersPage() {
         email: '',
         name: '',
         password: '',
-        role: 'MANAGER',
+        role: defaultRole,
         isActive: true,
       });
     }
@@ -224,17 +252,21 @@ export default function UsersPage() {
     <div className="space-y-4 md:space-y-6">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">{t('title')}</h1>
-          <p className="text-sm md:text-base text-muted-foreground">{t('description')}</p>
+          <h1 className="text-2xl font-bold tracking-tight md:text-3xl">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground md:text-base">{t('description')}</p>
         </div>
-        <Button onClick={() => handleOpenDialog()} className="w-full md:w-auto min-h-[44px] md:min-h-0">
+        <Button
+          onClick={() => handleOpenDialog()}
+          className="min-h-[44px] w-full md:min-h-0 md:w-auto"
+          disabled={assignableRoles.length === 0}
+        >
           <Plus className="mr-2 h-4 w-4" />
           {t('addUser')}
         </Button>
       </div>
 
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:gap-4">
-        <div className="relative w-full md:flex-1 md:max-w-sm">
+        <div className="relative w-full md:max-w-sm md:flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder={t('searchPlaceholder')}
@@ -243,7 +275,7 @@ export default function UsersPage() {
               setPagination((current) => ({ ...current, page: 1 }));
               setSearch(e.target.value);
             }}
-            className="pl-9 h-11 md:h-10 text-base md:text-sm"
+            className="h-11 pl-9 text-base md:h-10 md:text-sm"
           />
         </div>
         <Select
@@ -253,7 +285,7 @@ export default function UsersPage() {
             setRoleFilter(value);
           }}
         >
-          <SelectTrigger className="w-full md:w-[180px] h-11 md:h-10">
+          <SelectTrigger className="h-11 w-full md:h-10 md:w-[180px]">
             <SelectValue placeholder={t('allRoles')} />
           </SelectTrigger>
           <SelectContent>
@@ -294,103 +326,126 @@ export default function UsersPage() {
                     </TableCell>
                   </TableRow>
                 ) : (
-                  users.map((user) => (
-                    <TableRow
-                      key={user.id}
-                      tabIndex={0}
-                      className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-                      onClick={() => handleOpenDialog(user)}
-                      onKeyDown={(event) =>
-                        handleClickableRowKeyDown(event, () => handleOpenDialog(user))
-                      }
-                    >
-                      <TableCell>
-                        <div className="flex items-center space-x-2">
-                          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
-                            <Users className="h-4 w-4 text-primary" />
+                  users.map((user) => {
+                    const isManageable = canManageRole(user.role);
+
+                    return (
+                      <TableRow
+                        key={user.id}
+                        tabIndex={isManageable ? 0 : undefined}
+                        className={
+                          isManageable
+                            ? 'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring'
+                            : undefined
+                        }
+                        onClick={() => {
+                          if (isManageable) handleOpenDialog(user);
+                        }}
+                        onKeyDown={(event) => {
+                          if (isManageable) {
+                            handleClickableRowKeyDown(event, () => handleOpenDialog(user));
+                          }
+                        }}
+                      >
+                        <TableCell>
+                          <div className="flex items-center space-x-2">
+                            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
+                              <Users className="h-4 w-4 text-primary" />
+                            </div>
+                            <div>
+                              <p className="font-medium">{user.name || 'No name'}</p>
+                              <p className="text-xs text-muted-foreground">{user.email}</p>
+                            </div>
                           </div>
-                          <div>
-                            <p className="font-medium">{user.name || 'No name'}</p>
-                            <p className="text-xs text-muted-foreground">{user.email}</p>
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant={roleLabels[user.role]?.color as 'default' | 'secondary' | 'destructive' | 'outline'}>
-                          {roleLabels[user.role]?.label || user.role}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex flex-col gap-1">
-                          <Badge variant={user.isActive ? 'default' : 'secondary'}>
-                            {user.isActive ? t('active') : tc('inactive')}
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              roleLabels[user.role]?.color as
+                                | 'default'
+                                | 'secondary'
+                                | 'destructive'
+                                | 'outline'
+                            }
+                          >
+                            {roleLabels[user.role]?.label || user.role}
                           </Badge>
-                          {user.isSuspended && (
-                            <Badge variant="destructive">{t('suspended')}</Badge>
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        {user.lastLoginAt ? (
-                          <span className="text-sm">
-                            {formatDistanceToNow(new Date(user.lastLoginAt), { addSuffix: true })}
-                          </span>
-                        ) : (
-                          <span className="text-sm text-muted-foreground">{t('never')}</span>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex flex-col gap-1 text-xs">
-                          <span>{user._count.violations} violations logged</span>
-                          <span>{user._count.managedBuildings} buildings</span>
-                        </div>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <div className="flex justify-end gap-2">
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={(event) => {
-                              stopClickableRowPropagation(event);
-                              handleOpenDialog(user);
-                            }}
-                            title="Edit user"
-                            onKeyDown={stopClickableRowPropagation}
-                          >
-                            <Edit2 className="h-4 w-4" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={(event) => {
-                              stopClickableRowPropagation(event);
-                              handleToggleSuspend(user);
-                            }}
-                            title={user.isSuspended ? 'Unsuspend user' : 'Suspend user'}
-                            onKeyDown={stopClickableRowPropagation}
-                          >
-                            {user.isSuspended ? (
-                              <CheckCircle className="h-4 w-4 text-green-600" />
-                            ) : (
-                              <Ban className="h-4 w-4 text-orange-600" />
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex flex-col gap-1">
+                            <Badge variant={user.isActive ? 'default' : 'secondary'}>
+                              {user.isActive ? t('active') : tc('inactive')}
+                            </Badge>
+                            {user.isSuspended && (
+                              <Badge variant="destructive">{t('suspended')}</Badge>
                             )}
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={(event) => {
-                              stopClickableRowPropagation(event);
-                              handleDelete(user);
-                            }}
-                            title="Delete user"
-                            onKeyDown={stopClickableRowPropagation}
-                          >
-                            <Trash2 className="h-4 w-4 text-destructive" />
-                          </Button>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          {user.lastLoginAt ? (
+                            <span className="text-sm">
+                              {formatDistanceToNow(new Date(user.lastLoginAt), { addSuffix: true })}
+                            </span>
+                          ) : (
+                            <span className="text-sm text-muted-foreground">{t('never')}</span>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex flex-col gap-1 text-xs">
+                            <span>{user._count.violations} violations logged</span>
+                            <span>{user._count.managedBuildings} buildings</span>
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex justify-end gap-2">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={(event) => {
+                                stopClickableRowPropagation(event);
+                                handleOpenDialog(user);
+                              }}
+                              title="Edit user"
+                              onKeyDown={stopClickableRowPropagation}
+                              disabled={!isManageable}
+                            >
+                              <Edit2 className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={(event) => {
+                                stopClickableRowPropagation(event);
+                                handleToggleSuspend(user);
+                              }}
+                              title={user.isSuspended ? 'Unsuspend user' : 'Suspend user'}
+                              onKeyDown={stopClickableRowPropagation}
+                              disabled={!isManageable}
+                            >
+                              {user.isSuspended ? (
+                                <CheckCircle className="h-4 w-4 text-green-600" />
+                              ) : (
+                                <Ban className="h-4 w-4 text-orange-600" />
+                              )}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={(event) => {
+                                stopClickableRowPropagation(event);
+                                handleDelete(user);
+                              }}
+                              title="Delete user"
+                              onKeyDown={stopClickableRowPropagation}
+                              disabled={!isManageable}
+                            >
+                              <Trash2 className="h-4 w-4 text-destructive" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
                 )}
               </TableBody>
             </Table>
@@ -421,7 +476,7 @@ export default function UsersPage() {
                   type="email"
                   value={formData.email}
                   onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                  className="h-11 md:h-10 text-base md:text-sm"
+                  className="h-11 text-base md:h-10 md:text-sm"
                   required
                   disabled={!!editingUser}
                 />
@@ -432,7 +487,7 @@ export default function UsersPage() {
                   id="name"
                   value={formData.name}
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="h-11 md:h-10 text-base md:text-sm"
+                  className="h-11 text-base md:h-10 md:text-sm"
                 />
               </div>
               <div className="space-y-2">
@@ -442,7 +497,7 @@ export default function UsersPage() {
                   type="password"
                   value={formData.password}
                   onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                  className="h-11 md:h-10 text-base md:text-sm"
+                  className="h-11 text-base md:h-10 md:text-sm"
                   placeholder={editingUser ? 'Leave blank to keep current' : 'Required'}
                   required={!editingUser}
                 />
@@ -457,9 +512,11 @@ export default function UsersPage() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="MANAGER">{t('manager')}</SelectItem>
-                    <SelectItem value="ADMIN">{t('admin')}</SelectItem>
-                    <SelectItem value="SECURITY">{t('security')}</SelectItem>
+                    {assignableRoles.map((role) => (
+                      <SelectItem key={role} value={role}>
+                        {roleLabels[role]?.label || role}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -478,7 +535,12 @@ export default function UsersPage() {
               </div>
             </div>
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setIsDialogOpen(false)} className="min-h-[44px] md:min-h-0">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setIsDialogOpen(false)}
+                className="min-h-[44px] md:min-h-0"
+              >
                 {tc('cancel')}
               </Button>
               <Button type="submit" className="min-h-[44px] md:min-h-0">

--- a/src/app/api/users/__tests__/route.test.ts
+++ b/src/app/api/users/__tests__/route.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createMockGetRequest, createMockPostRequest, createMockRequest } from '@/test/mocks/next-request';
+import {
+  createMockGetRequest,
+  createMockPostRequest,
+  createMockRequest,
+} from '@/test/mocks/next-request';
 
 vi.mock('@/lib/api-auth', () => ({
   requirePermission: vi.fn(),
@@ -10,6 +14,7 @@ vi.mock('@/lib/prisma', () => ({
     user: {
       findMany: vi.fn(),
       findUnique: vi.fn(),
+      count: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
     },
@@ -34,6 +39,7 @@ const mockPrisma = prisma as unknown as {
   user: {
     findMany: ReturnType<typeof vi.fn>;
     findUnique: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
   };
@@ -51,19 +57,27 @@ const adminAuthResult = {
   },
 };
 
+const superAdminAuthResult = {
+  authorized: true as const,
+  request: {
+    userId: 'super-admin-1',
+    role: 'SUPER_ADMIN',
+    auth: {} as never,
+  },
+};
+
 describe('Users API route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequirePermission.mockResolvedValue(adminAuthResult);
     mockPrisma.user.findMany.mockResolvedValue([]);
     mockPrisma.user.findUnique.mockResolvedValue(null);
+    mockPrisma.user.count.mockResolvedValue(0);
     mockPrisma.auditLog.create.mockResolvedValue({});
   });
 
   it('excludes resident accounts from the list query', async () => {
-    const response = await GET(
-      createMockGetRequest('http://localhost:3000/api/users')
-    );
+    const response = await GET(createMockGetRequest('http://localhost:3000/api/users'));
 
     expect(response.status).toBe(200);
     expect(mockPrisma.user.findMany).toHaveBeenCalledWith(
@@ -89,6 +103,78 @@ describe('Users API route', () => {
     expect(data.error).toBeTruthy();
   });
 
+  it('allows super admins to create super admin accounts', async () => {
+    mockRequirePermission.mockResolvedValue(superAdminAuthResult);
+    mockPrisma.user.create.mockResolvedValue({
+      id: 'super-admin-2',
+      email: 'new-super-admin@example.com',
+      name: null,
+      role: 'SUPER_ADMIN',
+      isActive: true,
+      createdAt: new Date(),
+    });
+
+    const response = await POST(
+      createMockPostRequest('http://localhost:3000/api/users', {
+        email: 'new-super-admin@example.com',
+        password: 'Admin@123!',
+        role: 'SUPER_ADMIN',
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockPrisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          role: 'SUPER_ADMIN',
+        }),
+      })
+    );
+  });
+
+  it('prevents admins from creating peer or upstream accounts', async () => {
+    const response = await POST(
+      createMockPostRequest('http://localhost:3000/api/users', {
+        email: 'peer-admin@example.com',
+        password: 'Admin@123!',
+        role: 'ADMIN',
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toContain('roles below your own');
+    expect(mockPrisma.user.create).not.toHaveBeenCalled();
+  });
+
+  it('allows admins to create downstream accounts', async () => {
+    mockPrisma.user.create.mockResolvedValue({
+      id: 'manager-1',
+      email: 'manager@example.com',
+      name: null,
+      role: 'MANAGER',
+      isActive: true,
+      createdAt: new Date(),
+    });
+
+    const response = await POST(
+      createMockPostRequest('http://localhost:3000/api/users', {
+        email: 'manager@example.com',
+        password: 'Admin@123!',
+        role: 'MANAGER',
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockPrisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          role: 'MANAGER',
+        }),
+      })
+    );
+  });
+
   it('blocks resident account updates through the generic users endpoint', async () => {
     mockPrisma.user.findUnique.mockResolvedValue({
       id: 'resident-user-1',
@@ -109,6 +195,46 @@ describe('Users API route', () => {
     expect(mockPrisma.user.update).not.toHaveBeenCalled();
   });
 
+  it('prevents admins from modifying peer accounts', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'admin-2',
+      role: 'ADMIN',
+      email: 'peer-admin@example.com',
+    });
+
+    const response = await PATCH(
+      createMockRequest('http://localhost:3000/api/users?id=admin-2', {
+        method: 'PATCH',
+        body: { name: 'Updated Admin' },
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toContain('roles below your own');
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('prevents admins from promoting downstream accounts to peer roles', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'manager-1',
+      role: 'MANAGER',
+      email: 'manager@example.com',
+    });
+
+    const response = await PATCH(
+      createMockRequest('http://localhost:3000/api/users?id=manager-1', {
+        method: 'PATCH',
+        body: { role: 'ADMIN' },
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toContain('roles below your own');
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
   it('blocks resident account deletes through the generic users endpoint', async () => {
     mockPrisma.user.findUnique.mockResolvedValue({
       id: 'resident-user-1',
@@ -125,6 +251,25 @@ describe('Users API route', () => {
 
     expect(response.status).toBe(403);
     expect(data.error).toContain('registration passes');
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('prevents admins from deleting peer accounts', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: 'admin-2',
+      role: 'ADMIN',
+      email: 'peer-admin@example.com',
+    });
+
+    const response = await DELETE(
+      createMockRequest('http://localhost:3000/api/users?id=admin-2', {
+        method: 'DELETE',
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toContain('roles below your own');
     expect(mockPrisma.user.update).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import { strongPasswordSchema } from '@/lib/validation';
+import { canAssignStaffRole, canManageStaffRole } from '@/lib/authorization';
 
 const createUserSchema = z.object({
   email: z.string().email('Invalid email address'),
@@ -124,10 +125,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'A user with this email already exists' }, { status: 400 });
     }
 
-    // Prevent non-super admins from creating super admins
-    if (validatedData.role === 'SUPER_ADMIN' && authResult.request.role !== 'SUPER_ADMIN') {
+    if (!canAssignStaffRole(authResult.request.role, validatedData.role)) {
       return NextResponse.json(
-        { error: 'Only super admins can create super admin accounts' },
+        { error: 'You can only create accounts for roles below your own' },
         { status: 403 }
       );
     }
@@ -207,10 +207,9 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
-    // Prevent non-super admins from modifying super admin accounts
-    if (existingUser.role === 'SUPER_ADMIN' && authResult.request.role !== 'SUPER_ADMIN') {
+    if (!canManageStaffRole(authResult.request.role, existingUser.role)) {
       return NextResponse.json(
-        { error: 'Only super admins can modify super admin accounts' },
+        { error: 'You can only manage accounts for roles below your own' },
         { status: 403 }
       );
     }
@@ -223,6 +222,16 @@ export async function PATCH(request: NextRequest) {
       if (validatedData.isSuspended === true) {
         return NextResponse.json({ error: 'Cannot suspend your own account' }, { status: 400 });
       }
+    }
+
+    if (
+      validatedData.role !== undefined &&
+      !canAssignStaffRole(authResult.request.role, validatedData.role)
+    ) {
+      return NextResponse.json(
+        { error: 'You can only assign roles below your own' },
+        { status: 403 }
+      );
     }
 
     const updateData: Record<string, unknown> = {};
@@ -315,10 +324,9 @@ export async function DELETE(request: NextRequest) {
       );
     }
 
-    // Prevent non-super admins from deleting super admin accounts
-    if (user.role === 'SUPER_ADMIN' && authResult.request.role !== 'SUPER_ADMIN') {
+    if (!canManageStaffRole(authResult.request.role, user.role)) {
       return NextResponse.json(
-        { error: 'Only super admins can delete super admin accounts' },
+        { error: 'You can only delete accounts for roles below your own' },
         { status: 403 }
       );
     }

--- a/src/lib/authorization.ts
+++ b/src/lib/authorization.ts
@@ -45,7 +45,8 @@ export type Permission =
 
 /**
  * Role-to-permissions mapping.
- * SUPER_ADMIN and ADMIN have full access.
+ * SUPER_ADMIN has system-level access.
+ * ADMIN has administrative access without super-admin-only system control.
  * MANAGER has operational access without system administration.
  * SECURITY has limited view/log access for day-to-day operations.
  * RESIDENT can only view/manage their own passes.
@@ -189,6 +190,47 @@ export function hasAllPermissions(role: UserRole, permissions: Permission[]): bo
  */
 export function getPermissions(role: UserRole): Permission[] {
   return ROLE_PERMISSIONS[role] ?? [];
+}
+
+const ROLE_RANK: Record<UserRole, number> = {
+  SUPER_ADMIN: 4,
+  ADMIN: 3,
+  MANAGER: 2,
+  SECURITY: 1,
+  RESIDENT: 0,
+};
+
+const STAFF_ROLES: UserRole[] = ['SUPER_ADMIN', 'ADMIN', 'MANAGER', 'SECURITY'];
+
+/**
+ * Get staff roles an actor can assign to another staff account.
+ * SUPER_ADMIN can assign every staff role. Other roles can only assign roles below their own.
+ */
+export function getAssignableStaffRoles(actorRole: UserRole): UserRole[] {
+  if (actorRole === 'SUPER_ADMIN') {
+    return STAFF_ROLES;
+  }
+
+  const actorRank = ROLE_RANK[actorRole];
+  return STAFF_ROLES.filter((role) => ROLE_RANK[role] < actorRank);
+}
+
+/**
+ * Check if a role can create or assign another staff role.
+ */
+export function canAssignStaffRole(actorRole: UserRole, targetRole: UserRole): boolean {
+  return getAssignableStaffRoles(actorRole).includes(targetRole);
+}
+
+/**
+ * Check if a role can manage an existing staff account.
+ */
+export function canManageStaffRole(actorRole: UserRole, targetRole: UserRole): boolean {
+  if (targetRole === 'RESIDENT') {
+    return false;
+  }
+
+  return actorRole === 'SUPER_ADMIN' || ROLE_RANK[targetRole] < ROLE_RANK[actorRole];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Enforces downstream-only staff account creation and role assignment in the users API.
- Updates the dashboard Users page so super admins can create all staff roles while lower roles only see roles below their own.
- Adds targeted API coverage for super-admin creation, downstream account creation, and blocked peer/upstream management.
- Adds role documentation at `docs/roles-and-access.md` defining responsibilities and access levels for Super Admin, Admin, Manager, Security, and Resident.

## Validation
- `pnpm test src/app/api/users/__tests__/route.test.ts`
- `pnpm type-check`
- `pnpm exec prettier --check docs/roles-and-access.md src/lib/authorization.ts src/app/api/users/route.ts src/app/api/users/__tests__/route.test.ts 'src/app/(dashboard)/dashboard/users/page.tsx'`